### PR TITLE
pass req to decide function

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -153,7 +153,12 @@ Test.prototype.decide = function(err) {
     }
     
     var fn = self._mod.response;
-    fn(txn, res, next);
+    if (fn.length === 4) {
+      var req = new Request();
+      fn(txn, req, res, next);
+    } else {
+      fn(txn, res, next);
+    }
   }
   
   if (before && before.length == 2) {


### PR DESCRIPTION
This addition checks the arity of the callback to pass the req
object only when needed.
